### PR TITLE
Added URL encoding of username and password in NexusCredentials to avoid MalformedURLExceptions.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/bobby/Nexus.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/Nexus.scala
@@ -15,12 +15,11 @@
  */
 package uk.gov.hmrc.bobby
 
-import java.net.URL
+import java.net.{URL, URLEncoder}
 
 import sbt.{Logger, ModuleID}
 import uk.gov.hmrc.bobby.conf.ConfigFile
 
-import scala.io.Source
 import scala.util.{Failure, Success, Try}
 import scala.xml.{NodeSeq, XML}
 
@@ -72,7 +71,8 @@ object Nexus{
   }
 
   case class NexusCredentials(host:String, username:String, password:String){
-    def buildSearchUrl(searchQuery:String) = s"https://${username}:${password}@${host}/service/local/lucene/search?a=$searchQuery"
+    import java.net.URLEncoder.encode
+    def buildSearchUrl(searchQuery:String) = s"https://${encode(username, "UTF-8")}:${encode(password, "UTF-8")}@${host}/service/local/lucene/search?a=$searchQuery"
   }
 
 

--- a/src/test/scala/uk/gov/hmrc/bobby/NexusCredentialsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/NexusCredentialsSpec.scala
@@ -1,0 +1,26 @@
+package uk.gov.hmrc.bobby
+
+import java.net.URL
+
+import org.scalatest.{FlatSpec, Matchers}
+import uk.gov.hmrc.bobby.Nexus.NexusCredentials
+
+import scala.util.Try
+
+class NexusCredentialsSpec extends FlatSpec with Matchers {
+
+  "buildsearchUrl" should
+    "build valid URL" in {
+      val result = NexusCredentials("nexus.host.com", "myUsername", "somePassword").buildSearchUrl("query")
+      result shouldBe "https://myUsername:somePassword@nexus.host.com/service/local/lucene/search?a=query"
+      Try(new URL(result)).toOption shouldBe defined
+    }
+
+    it should "encode characters that may break the URL" in {
+    val result = NexusCredentials("nexus.host.com", "myUsername@mydomain.com", "someP!ssword").buildSearchUrl("query")
+    result shouldBe "https://myUsername%40mydomain.com:someP%21ssword@nexus.host.com/service/local/lucene/search?a=query"
+    Try(new URL(result)).toOption shouldBe defined
+  }
+
+
+}


### PR DESCRIPTION
I was trying to setting up bobby on my local env and noticed that Nexus credentials are not URL encoded, which in my case need to be.